### PR TITLE
Add filter by attributes to productVariants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@ Like `reference`, the `single-reference` type can target entities defined in the
   - Attribute slug is now optional when filtering by attribute values
   - Added support for filtering by associated reference objects (e.g., `products`, `pages`, `variants`)
 - Added `fractionalAmount` and `fractionDigits` fields to the `Money` type. These fields allow monetary values to be represented as a pair of integers, which is often required when integrating with payment service providers.
+- Add support for filtering `productVariants` by associated attributes
 
 ### Webhooks
 - Transaction webhooks responsible for processing payments can now return payment method details`, which will be associated with the corresponding transaction. See [docs](https://docs.saleor.io/developer/extending/webhooks/synchronous-events/transaction#response-4) to learn more.

--- a/saleor/graphql/product/filters/product_variant.py
+++ b/saleor/graphql/product/filters/product_variant.py
@@ -1,30 +1,41 @@
 import django_filters
 import graphene
 from django.db.models import Exists, OuterRef, Q
+from django.db.models.query import QuerySet
 from django.utils import timezone
 
-from ....product.models import (
-    Product,
-    ProductVariant,
+from ....attribute.models import (
+    AssignedVariantAttribute,
+    AssignedVariantAttributeValue,
+    Attribute,
+    AttributeValue,
 )
+from ....product.models import Product, ProductVariant
+from ...attribute.shared_filters import (
+    AssignedAttributeWhereInput,
+    get_attribute_values_by_boolean_value,
+    get_attribute_values_by_date_time_value,
+    get_attribute_values_by_date_value,
+    get_attribute_values_by_numeric_value,
+    get_attribute_values_by_slug_or_name_value,
+    validate_attribute_value_input,
+)
+from ...core.descriptions import ADDED_IN_322
 from ...core.doc_category import DOC_CATEGORY_PRODUCTS
 from ...core.filters import (
     FilterInputObjectType,
     GlobalIDMultipleChoiceWhereFilter,
     ListObjectTypeFilter,
+    ListObjectTypeWhereFilter,
     MetadataFilterBase,
     MetadataWhereFilterBase,
     ObjectTypeFilter,
     ObjectTypeWhereFilter,
 )
-from ...core.filters.where_input import (
-    StringFilterInput,
-    WhereInputObjectType,
-)
-from ...core.types import (
-    DateTimeRangeInput,
-)
+from ...core.filters.where_input import StringFilterInput, WhereInputObjectType
+from ...core.types import DateTimeRangeInput
 from ...utils.filters import (
+    Number,
     filter_by_ids,
     filter_where_by_range_field,
     filter_where_by_value_field,
@@ -45,6 +56,181 @@ def filter_is_preorder(qs, _, value):
         Q(is_preorder=False)
         | (Q(is_preorder=True)) & Q(preorder_end_date__lt=timezone.now())
     )
+
+
+def filter_by_slug_or_name(
+    attr_id: int | None,
+    attr_value: dict,
+    db_connection_name: str,
+):
+    attribute_values = get_attribute_values_by_slug_or_name_value(
+        attr_id=attr_id,
+        attr_value=attr_value,
+        db_connection_name=db_connection_name,
+    )
+    return _get_assigned_variant_attribute_for_attribute_value_qs(
+        attribute_values,
+        db_connection_name,
+    )
+
+
+def filter_by_numeric_attribute(
+    attr_id: int | None,
+    numeric_value: dict[str, Number | list[Number] | dict[str, Number]],
+    db_connection_name: str,
+):
+    qs_by_numeric = get_attribute_values_by_numeric_value(
+        attr_id=attr_id,
+        numeric_value=numeric_value,
+        db_connection_name=db_connection_name,
+    )
+    return _get_assigned_variant_attribute_for_attribute_value_qs(
+        qs_by_numeric,
+        db_connection_name,
+    )
+
+
+def filter_by_boolean_attribute(
+    attr_id: int | None,
+    boolean_value,
+    db_connection_name: str,
+):
+    qs_by_boolean = get_attribute_values_by_boolean_value(
+        attr_id=attr_id,
+        boolean_value=boolean_value,
+        db_connection_name=db_connection_name,
+    )
+    return _get_assigned_variant_attribute_for_attribute_value_qs(
+        qs_by_boolean,
+        db_connection_name,
+    )
+
+
+def filter_by_date_attribute(
+    attr_id: int | None,
+    date_value,
+    db_connection_name: str,
+):
+    qs_by_date = get_attribute_values_by_date_value(
+        attr_id=attr_id,
+        date_value=date_value,
+        db_connection_name=db_connection_name,
+    )
+    return _get_assigned_variant_attribute_for_attribute_value_qs(
+        qs_by_date,
+        db_connection_name,
+    )
+
+
+def filter_by_date_time_attribute(
+    attr_id: int | None,
+    date_value,
+    db_connection_name: str,
+):
+    qs_by_date_time = get_attribute_values_by_date_time_value(
+        attr_id=attr_id,
+        date_value=date_value,
+        db_connection_name=db_connection_name,
+    )
+    return _get_assigned_variant_attribute_for_attribute_value_qs(
+        qs_by_date_time,
+        db_connection_name,
+    )
+
+
+def _get_assigned_variant_attribute_for_attribute_value_qs(
+    attribute_values: QuerySet[AttributeValue],
+    db_connection_name: str,
+):
+    assigned_attr_value = AssignedVariantAttributeValue.objects.using(
+        db_connection_name
+    ).filter(
+        value__in=attribute_values,
+        assignment_id=OuterRef("id"),
+    )
+    return Q(
+        Exists(
+            AssignedVariantAttribute.objects.using(db_connection_name).filter(
+                Exists(assigned_attr_value), variant_id=OuterRef("pk")
+            )
+        )
+    )
+
+
+def filter_variants_by_attributes(
+    qs: QuerySet[ProductVariant], value: list[dict]
+) -> QuerySet[ProductVariant]:
+    attribute_slugs = {
+        attr_filter["slug"] for attr_filter in value if "slug" in attr_filter
+    }
+    attributes_map = {
+        attr.slug: attr
+        for attr in Attribute.objects.using(qs.db).filter(slug__in=attribute_slugs)
+    }
+    if len(attribute_slugs) != len(attributes_map.keys()):
+        # Filter over non existing attribute
+        return qs.none()
+
+    attr_filter_expression = Q()
+
+    attr_without_values_input = []
+    for attr_filter in value:
+        if "slug" in attr_filter and "value" not in attr_filter:
+            attr_without_values_input.append(attributes_map[attr_filter["slug"]])
+
+    if attr_without_values_input:
+        atr_value_qs = AttributeValue.objects.using(qs.db).filter(
+            attribute_id__in=[attr.id for attr in attr_without_values_input]
+        )
+        attr_filter_expression = _get_assigned_variant_attribute_for_attribute_value_qs(
+            atr_value_qs,
+            qs.db,
+        )
+
+    for attr_filter in value:
+        attr_value = attr_filter.get("value")
+        if not attr_value:
+            # attrs without value input are handled separately
+            continue
+
+        attr_id = None
+        if attr_slug := attr_filter.get("slug"):
+            attr = attributes_map[attr_slug]
+            attr_id = attr.id
+
+        attr_value = attr_filter["value"]
+
+        if "slug" in attr_value or "name" in attr_value:
+            attr_filter_expression &= filter_by_slug_or_name(
+                attr_id,
+                attr_value,
+                qs.db,
+            )
+        elif "numeric" in attr_value:
+            attr_filter_expression &= filter_by_numeric_attribute(
+                attr_id,
+                attr_value["numeric"],
+                qs.db,
+            )
+        elif "boolean" in attr_value:
+            attr_filter_expression &= filter_by_boolean_attribute(
+                attr_id,
+                attr_value["boolean"],
+                qs.db,
+            )
+        elif "date" in attr_value:
+            attr_filter_expression &= filter_by_date_attribute(
+                attr_id,
+                attr_value["date"],
+                qs.db,
+            )
+        elif "date_time" in attr_value:
+            attr_filter_expression &= filter_by_date_time_attribute(
+                attr_id,
+                attr_value["date_time"],
+                qs.db,
+            )
+    return qs.filter(attr_filter_expression)
 
 
 class ProductVariantFilter(MetadataFilterBase):
@@ -82,6 +268,11 @@ class ProductVariantWhere(MetadataWhereFilterBase):
         method="filter_updated_at",
         help_text="Filter by when was the most recent update.",
     )
+    attributes = ListObjectTypeWhereFilter(
+        input_class=AssignedAttributeWhereInput,
+        method="filter_attributes",
+        help_text="Filter by attributes associated with the variant." + ADDED_IN_322,
+    )
 
     class Meta:
         model = ProductVariant
@@ -94,6 +285,17 @@ class ProductVariantWhere(MetadataWhereFilterBase):
     @staticmethod
     def filter_updated_at(qs, _, value):
         return filter_where_by_range_field(qs, "updated_at", value)
+
+    @staticmethod
+    def filter_attributes(qs, _, value):
+        if not value:
+            return qs
+        return filter_variants_by_attributes(qs, value)
+
+    def is_valid(self):
+        if attributes := self.data.get("attributes"):
+            validate_attribute_value_input(attributes, self.queryset.db)
+        return super().is_valid()
 
 
 class ProductVariantFilterInput(FilterInputObjectType):

--- a/saleor/graphql/product/tests/queries/variants_where/shared.py
+++ b/saleor/graphql/product/tests/queries/variants_where/shared.py
@@ -1,0 +1,13 @@
+PRODUCT_VARIANTS_WHERE_QUERY = """
+    query($where: ProductVariantWhereInput!, $channel: String) {
+      productVariants(first: 10, where: $where, channel: $channel) {
+        edges {
+          node {
+            id
+            name
+            sku
+          }
+        }
+      }
+    }
+"""

--- a/saleor/graphql/product/tests/queries/variants_where/test_over_attributes.py
+++ b/saleor/graphql/product/tests/queries/variants_where/test_over_attributes.py
@@ -1,0 +1,166 @@
+import graphene
+import pytest
+
+from ......attribute.utils import associate_attribute_values_to_instance
+from .....tests.utils import get_graphql_content
+from .shared import PRODUCT_VARIANTS_WHERE_QUERY
+
+
+def test_product_variants_query_with_attribute_slug(
+    staff_api_client, product_variant_list, weight_attribute, channel_USD
+):
+    # given
+    product_type = product_variant_list[0].product.product_type
+    product_type.variant_attributes.add(weight_attribute)
+    attr_value = weight_attribute.values.first()
+
+    associate_attribute_values_to_instance(
+        product_variant_list[0], {weight_attribute.pk: [attr_value]}
+    )
+
+    variables = {
+        "where": {"attributes": [{"slug": weight_attribute.slug}]},
+        "channel": channel_USD.slug,
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        PRODUCT_VARIANTS_WHERE_QUERY,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    product_variants_nodes = content["data"]["productVariants"]["edges"]
+    assert len(product_variants_nodes) == 1
+    assert product_variants_nodes[0]["node"]["id"] == graphene.Node.to_global_id(
+        "ProductVariant", product_variant_list[0].pk
+    )
+
+
+@pytest.mark.parametrize(
+    ("attribute_input", "expected_count"),
+    [
+        ({"value": {"slug": {"eq": "test-slug-1"}}}, 1),
+        ({"value": {"slug": {"oneOf": ["test-slug-1", "test-slug-2"]}}}, 2),
+        ({"slug": "weight_attribute", "value": {"slug": {"eq": "test-slug-1"}}}, 1),
+        (
+            {
+                "slug": "weight_attribute",
+                "value": {"slug": {"oneOf": ["test-slug-1", "test-slug-2"]}},
+            },
+            2,
+        ),
+    ],
+)
+def test_product_variants_query_with_attribute_value_slug(
+    attribute_input,
+    expected_count,
+    staff_api_client,
+    product_variant_list,
+    weight_attribute,
+    channel_USD,
+):
+    # given
+    weight_attribute.slug = "weight_attribute"
+    weight_attribute.save()
+
+    product_variant_list[0].product.product_type.variant_attributes.add(
+        weight_attribute
+    )
+
+    attr_value_1 = weight_attribute.values.first()
+    attr_value_1.slug = "test-slug-1"
+    attr_value_1.save()
+
+    attr_value_2 = weight_attribute.values.last()
+    attr_value_2.slug = "test-slug-2"
+    attr_value_2.save()
+
+    associate_attribute_values_to_instance(
+        product_variant_list[0], {weight_attribute.pk: [attr_value_1]}
+    )
+
+    associate_attribute_values_to_instance(
+        product_variant_list[1], {weight_attribute.pk: [attr_value_2]}
+    )
+
+    variables = {
+        "where": {"attributes": [attribute_input]},
+        "channel": channel_USD.slug,
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        PRODUCT_VARIANTS_WHERE_QUERY,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    product_variants_nodes = content["data"]["productVariants"]["edges"]
+    assert len(product_variants_nodes) == expected_count
+
+
+@pytest.mark.parametrize(
+    ("attribute_input", "expected_count"),
+    [
+        ({"value": {"name": {"eq": "test-name-1"}}}, 1),
+        ({"value": {"name": {"oneOf": ["test-name-1", "test-name-2"]}}}, 2),
+        ({"slug": "weight_attribute", "value": {"name": {"eq": "test-name-1"}}}, 1),
+        (
+            {
+                "slug": "weight_attribute",
+                "value": {"name": {"oneOf": ["test-name-1", "test-name-2"]}},
+            },
+            2,
+        ),
+    ],
+)
+def test_product_variants_query_with_attribute_value_name(
+    attribute_input,
+    expected_count,
+    staff_api_client,
+    product_variant_list,
+    weight_attribute,
+    channel_USD,
+):
+    # given
+    weight_attribute.slug = "weight_attribute"
+    weight_attribute.save()
+
+    product_variant_list[0].product.product_type.variant_attributes.add(
+        weight_attribute
+    )
+
+    attr_value_1 = weight_attribute.values.first()
+    attr_value_1.name = "test-name-1"
+    attr_value_1.save()
+
+    attr_value_2 = weight_attribute.values.last()
+    attr_value_2.name = "test-name-2"
+    attr_value_2.save()
+
+    associate_attribute_values_to_instance(
+        product_variant_list[0], {weight_attribute.pk: [attr_value_1]}
+    )
+
+    associate_attribute_values_to_instance(
+        product_variant_list[1], {weight_attribute.pk: [attr_value_2]}
+    )
+
+    variables = {
+        "where": {"attributes": [attribute_input]},
+        "channel": channel_USD.slug,
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        PRODUCT_VARIANTS_WHERE_QUERY,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    product_variants_nodes = content["data"]["productVariants"]["edges"]
+    assert len(product_variants_nodes) == expected_count

--- a/saleor/graphql/product/tests/queries/variants_where/test_over_attributes_boolean.py
+++ b/saleor/graphql/product/tests/queries/variants_where/test_over_attributes_boolean.py
@@ -1,0 +1,84 @@
+import graphene
+import pytest
+
+from ......attribute import AttributeInputType, AttributeType
+from ......attribute.models import Attribute, AttributeValue
+from ......attribute.utils import associate_attribute_values_to_instance
+from .....tests.utils import get_graphql_content
+from .shared import PRODUCT_VARIANTS_WHERE_QUERY
+
+
+@pytest.mark.parametrize(
+    "boolean_input",
+    [
+        {"value": {"boolean": True}},
+        {"value": {"name": {"eq": "True-name"}}},
+        {"value": {"slug": {"eq": "true_slug"}}},
+        {"value": {"name": {"oneOf": ["True-name", "non-existing"]}}},
+        {"value": {"slug": {"oneOf": ["true_slug"]}}},
+        {"slug": "b_s", "value": {"boolean": True}},
+        {"slug": "b_s", "value": {"name": {"eq": "True-name"}}},
+        {"slug": "b_s", "value": {"slug": {"eq": "true_slug"}}},
+        {"slug": "b_s", "value": {"name": {"oneOf": ["True-name", "non-existing"]}}},
+        {"slug": "b_s", "value": {"slug": {"oneOf": ["true_slug"]}}},
+    ],
+)
+def test_product_variants_query_with_attribute_value_boolean(
+    boolean_input,
+    staff_api_client,
+    product_variant_list,
+    boolean_attribute,
+    channel_USD,
+):
+    # given
+    product = product_variant_list[0].product
+    product_type = product.product_type
+
+    boolean_attribute.slug = "b_s"
+    boolean_attribute.save()
+
+    second_attribute = Attribute.objects.create(
+        slug="s_boolean",
+        name="Boolean",
+        type=AttributeType.PRODUCT_TYPE,
+        input_type=AttributeInputType.BOOLEAN,
+    )
+
+    product_type.variant_attributes.add(boolean_attribute, second_attribute)
+
+    true_value = boolean_attribute.values.filter(boolean=True).first()
+    true_value.name = "True-name"
+    true_value.slug = "true_slug"
+    true_value.save()
+
+    variant_1 = product_variant_list[0]
+    associate_attribute_values_to_instance(
+        variant_1, {boolean_attribute.pk: [true_value]}
+    )
+
+    variant_2 = product_variant_list[1]
+    value_for_second_attr = AttributeValue.objects.create(
+        attribute=second_attribute,
+        name=f"{second_attribute.name}: Yes",
+        slug=f"{second_attribute.id}_false",
+        boolean=False,
+    )
+    associate_attribute_values_to_instance(
+        variant_2, {second_attribute.pk: [value_for_second_attr]}
+    )
+
+    variables = {"where": {"attributes": [boolean_input]}, "channel": channel_USD.slug}
+
+    # when
+    response = staff_api_client.post_graphql(
+        PRODUCT_VARIANTS_WHERE_QUERY,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    variants_nodes = content["data"]["productVariants"]["edges"]
+    assert len(variants_nodes) == 1
+    assert variants_nodes[0]["node"]["id"] == graphene.Node.to_global_id(
+        "ProductVariant", variant_1.pk
+    )

--- a/saleor/graphql/product/tests/queries/variants_where/test_over_attributes_date.py
+++ b/saleor/graphql/product/tests/queries/variants_where/test_over_attributes_date.py
@@ -1,0 +1,104 @@
+import datetime
+
+import pytest
+
+from ......attribute import AttributeInputType, AttributeType
+from ......attribute.models import Attribute
+from ......attribute.utils import associate_attribute_values_to_instance
+from .....tests.utils import get_graphql_content
+from .shared import PRODUCT_VARIANTS_WHERE_QUERY
+
+
+@pytest.mark.parametrize(
+    ("date_input", "expected_count"),
+    [
+        ({"slug": "date", "value": {"date": {"gte": "2021-01-01"}}}, 1),
+        ({"slug": "date", "value": {"name": {"eq": "date-name-1"}}}, 1),
+        ({"slug": "date", "value": {"slug": {"eq": "date-slug-1"}}}, 1),
+        (
+            {
+                "slug": "date",
+                "value": {"name": {"oneOf": ["date-name-1", "date-name-2"]}},
+            },
+            1,
+        ),
+        (
+            {
+                "slug": "date",
+                "value": {"slug": {"oneOf": ["date-slug-1", "date-slug-2"]}},
+            },
+            1,
+        ),
+        (
+            {
+                "slug": "date",
+                "value": {"date": {"gte": "2021-01-02", "lte": "2021-01-03"}},
+            },
+            1,
+        ),
+        ({"value": {"date": {"gte": "2021-01-01"}}}, 2),
+        ({"value": {"name": {"eq": "date-name-1"}}}, 1),
+        ({"value": {"slug": {"eq": "date-slug-1"}}}, 1),
+        ({"value": {"name": {"oneOf": ["date-name-1", "date-name-2"]}}}, 2),
+        ({"value": {"slug": {"oneOf": ["date-slug-1", "date-slug-2"]}}}, 2),
+        ({"value": {"date": {"gte": "2021-01-01", "lte": "2021-01-02"}}}, 1),
+    ],
+)
+def test_product_variants_query_with_attribute_value_date(
+    date_input,
+    expected_count,
+    staff_api_client,
+    product_variant_list,
+    date_attribute,
+    channel_USD,
+):
+    # given
+    product = product_variant_list[0].product
+    product_type = product.product_type
+
+    date_attribute.type = "PRODUCT_TYPE"
+    date_attribute.slug = "date"
+    date_attribute.save()
+
+    second_date_attribute = Attribute.objects.create(
+        slug="second_date",
+        name="Second date",
+        type=AttributeType.PRODUCT_TYPE,
+        input_type=AttributeInputType.DATE,
+    )
+    product_type.variant_attributes.add(date_attribute, second_date_attribute)
+
+    attr_value_1 = date_attribute.values.first()
+    attr_value_1.date_time = datetime.datetime(2021, 1, 3, tzinfo=datetime.UTC)
+    attr_value_1.name = "date-name-1"
+    attr_value_1.slug = "date-slug-1"
+    attr_value_1.save()
+
+    variant_1 = product_variant_list[0]
+    associate_attribute_values_to_instance(
+        variant_1, {date_attribute.pk: [attr_value_1]}
+    )
+
+    second_attr_value = second_date_attribute.values.create(
+        date_time=datetime.datetime(2021, 1, 2, tzinfo=datetime.UTC),
+        name="date-name-2",
+        slug="date-slug-2",
+    )
+
+    variant_2 = product_variant_list[1]
+    associate_attribute_values_to_instance(
+        variant_2, {second_date_attribute.pk: [second_attr_value]}
+    )
+
+    variables = {"where": {"attributes": [date_input]}, "channel": channel_USD.slug}
+
+    # when
+    response = staff_api_client.post_graphql(
+        PRODUCT_VARIANTS_WHERE_QUERY,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    variants_nodes = content["data"]["productVariants"]["edges"]
+    assert len(variants_nodes) == expected_count

--- a/saleor/graphql/product/tests/queries/variants_where/test_over_attributes_datetime.py
+++ b/saleor/graphql/product/tests/queries/variants_where/test_over_attributes_datetime.py
@@ -1,0 +1,131 @@
+import datetime
+
+import pytest
+
+from ......attribute import AttributeInputType, AttributeType
+from ......attribute.models import Attribute
+from ......attribute.utils import associate_attribute_values_to_instance
+from .....tests.utils import get_graphql_content
+from .shared import PRODUCT_VARIANTS_WHERE_QUERY
+
+
+@pytest.mark.parametrize(
+    ("date_time_input", "expected_count"),
+    [
+        ({"slug": "dt", "value": {"name": {"eq": "datetime-name-1"}}}, 1),
+        ({"slug": "dt", "value": {"slug": {"eq": "datetime-slug-1"}}}, 1),
+        (
+            {
+                "slug": "dt",
+                "value": {"name": {"oneOf": ["datetime-name-1", "datetime-name-2"]}},
+            },
+            2,
+        ),
+        (
+            {
+                "slug": "dt",
+                "value": {"slug": {"oneOf": ["datetime-slug-1", "datetime-slug-2"]}},
+            },
+            2,
+        ),
+        ({"slug": "dt", "value": {"dateTime": {"gte": "2021-01-01T00:00:00Z"}}}, 2),
+        (
+            {
+                "slug": "dt",
+                "value": {
+                    "dateTime": {
+                        "gte": "2021-01-01T00:00:00Z",
+                        "lte": "2021-01-02T00:00:00Z",
+                    }
+                },
+            },
+            1,
+        ),
+        ({"value": {"name": {"eq": "datetime-name-1"}}}, 1),
+        ({"value": {"slug": {"eq": "datetime-slug-1"}}}, 1),
+        ({"value": {"name": {"oneOf": ["datetime-name-1", "datetime-name-2"]}}}, 2),
+        ({"value": {"slug": {"oneOf": ["datetime-slug-1", "datetime-slug-2"]}}}, 2),
+        ({"value": {"dateTime": {"gte": "2021-01-01T00:00:00Z"}}}, 3),
+        (
+            {
+                "value": {
+                    "dateTime": {
+                        "gte": "2021-01-01T00:00:00Z",
+                        "lte": "2021-01-02T00:00:00Z",
+                    }
+                }
+            },
+            2,
+        ),
+    ],
+)
+def test_product_variants_query_with_attribute_value_date_time(
+    date_time_input,
+    expected_count,
+    staff_api_client,
+    product_variant_list,
+    date_time_attribute,
+    channel_USD,
+):
+    # given
+    product = product_variant_list[0].product
+    product_type = product.product_type
+
+    date_time_attribute.slug = "dt"
+    date_time_attribute.type = "PRODUCT_TYPE"
+    date_time_attribute.save()
+
+    second_date_attribute = Attribute.objects.create(
+        slug="second_dt",
+        name="Second dt",
+        type=AttributeType.PRODUCT_TYPE,
+        input_type=AttributeInputType.DATE_TIME,
+    )
+
+    product_type.variant_attributes.set([date_time_attribute, second_date_attribute])
+
+    attr_value_1 = date_time_attribute.values.first()
+    attr_value_1.date_time = datetime.datetime(2021, 1, 3, tzinfo=datetime.UTC)
+    attr_value_1.name = "datetime-name-1"
+    attr_value_1.slug = "datetime-slug-1"
+    attr_value_1.save()
+
+    associate_attribute_values_to_instance(
+        product_variant_list[0], {date_time_attribute.pk: [attr_value_1]}
+    )
+
+    second_attr_value = date_time_attribute.values.last()
+    second_attr_value.date_time = datetime.datetime(2021, 1, 1, tzinfo=datetime.UTC)
+    second_attr_value.name = "datetime-name-2"
+    second_attr_value.slug = "datetime-slug-2"
+    second_attr_value.save()
+
+    associate_attribute_values_to_instance(
+        product_variant_list[1], {date_time_attribute.pk: [second_attr_value]}
+    )
+
+    value_for_second_attr = second_date_attribute.values.create(
+        date_time=datetime.datetime(2021, 1, 1, tzinfo=datetime.UTC),
+        name="second-datetime-name",
+        slug="second-datetime-slug",
+    )
+
+    associate_attribute_values_to_instance(
+        product_variant_list[3], {second_date_attribute.pk: [value_for_second_attr]}
+    )
+
+    variables = {
+        "where": {"attributes": [date_time_input]},
+        "channel": channel_USD.slug,
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        PRODUCT_VARIANTS_WHERE_QUERY,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    variants_nodes = content["data"]["productVariants"]["edges"]
+    assert len(variants_nodes) == expected_count

--- a/saleor/graphql/product/tests/queries/variants_where/test_over_attributes_numeric.py
+++ b/saleor/graphql/product/tests/queries/variants_where/test_over_attributes_numeric.py
@@ -1,0 +1,88 @@
+import pytest
+
+from ......attribute.utils import associate_attribute_values_to_instance
+from .....tests.utils import get_graphql_content
+from .shared import PRODUCT_VARIANTS_WHERE_QUERY
+
+
+@pytest.mark.parametrize(
+    ("numeric_input", "expected_count"),
+    [
+        ({"slug": "num-slug", "value": {"numeric": {"eq": 1.2}}}, 1),
+        ({"slug": "num-slug", "value": {"numeric": {"oneOf": [1.2, 2]}}}, 2),
+        (
+            {"slug": "num-slug", "value": {"numeric": {"range": {"gte": 1, "lte": 2}}}},
+            2,
+        ),
+        ({"slug": "num-slug", "value": {"name": {"eq": "1.2"}}}, 1),
+        ({"slug": "num-slug", "value": {"slug": {"eq": "1.2"}}}, 1),
+        ({"slug": "num-slug", "value": {"name": {"oneOf": ["1.2", "2"]}}}, 2),
+        ({"slug": "num-slug", "value": {"slug": {"oneOf": ["1.2", "2"]}}}, 2),
+        ({"value": {"numeric": {"eq": 1.2}}}, 1),
+        ({"value": {"numeric": {"oneOf": [1.2, 2]}}}, 2),
+        ({"value": {"numeric": {"range": {"gte": 1, "lte": 2}}}}, 2),
+        ({"value": {"numeric": {"range": {"gte": 1}}}}, 3),
+        ({"value": {"name": {"eq": "1.2"}}}, 1),
+        ({"value": {"slug": {"eq": "1.2"}}}, 1),
+        ({"value": {"name": {"oneOf": ["1.2", "2"]}}}, 2),
+        ({"value": {"slug": {"oneOf": ["1.2", "2"]}}}, 2),
+    ],
+)
+def test_product_variants_query_with_attribute_value_numeric(
+    numeric_input,
+    expected_count,
+    staff_api_client,
+    product_type,
+    product_variant_list,
+    numeric_attribute_without_unit,
+    numeric_attribute,
+    channel_USD,
+):
+    # given
+    numeric_attribute_without_unit.slug = "num-slug"
+    numeric_attribute_without_unit.save()
+
+    product_type.variant_attributes.set(
+        [numeric_attribute_without_unit, numeric_attribute]
+    )
+
+    attr_value_1 = numeric_attribute_without_unit.values.first()
+    attr_value_1.name = "1.2"
+    attr_value_1.slug = "1.2"
+    attr_value_1.numeric = 1.2
+    attr_value_1.save()
+
+    attr_value_2 = numeric_attribute_without_unit.values.last()
+    attr_value_2.name = "2"
+    attr_value_2.slug = "2"
+    attr_value_2.numeric = 2
+    attr_value_2.save()
+
+    second_attr_value = numeric_attribute.values.first()
+
+    associate_attribute_values_to_instance(
+        product_variant_list[0],
+        {
+            numeric_attribute_without_unit.pk: [attr_value_1],
+        },
+    )
+
+    associate_attribute_values_to_instance(
+        product_variant_list[1], {numeric_attribute_without_unit.pk: [attr_value_2]}
+    )
+    associate_attribute_values_to_instance(
+        product_variant_list[3], {numeric_attribute.pk: [second_attr_value]}
+    )
+
+    variables = {"where": {"attributes": [numeric_input]}, "channel": channel_USD.slug}
+
+    # when
+    response = staff_api_client.post_graphql(
+        PRODUCT_VARIANTS_WHERE_QUERY,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    product_variants_nodes = content["data"]["productVariants"]["edges"]
+    assert len(product_variants_nodes) == expected_count

--- a/saleor/graphql/product/tests/queries/variants_where/test_over_multiple_arguments.py
+++ b/saleor/graphql/product/tests/queries/variants_where/test_over_multiple_arguments.py
@@ -1,0 +1,271 @@
+import pytest
+
+from ......attribute.utils import associate_attribute_values_to_instance
+from .....tests.utils import get_graphql_content
+from .shared import PRODUCT_VARIANTS_WHERE_QUERY
+
+
+@pytest.mark.parametrize(
+    "attribute_filter",
+    [
+        # Non-existing attribute slug
+        [{"slug": "non-existing-attribute"}],
+        # Existing attribute with non-existing value name
+        [{"slug": "tag", "value": {"name": {"eq": "Non-existing Name"}}}],
+        [{"value": {"name": {"eq": "Non-existing Name"}}}],
+        # Existing numeric attribute with out-of-range value
+        [{"slug": "count", "value": {"numeric": {"eq": 999}}}],
+        [{"value": {"numeric": {"eq": 999}}}],
+        # Existing boolean attribute with no matching boolean value
+        [{"slug": "boolean", "value": {"boolean": False}}],
+        [{"value": {"boolean": False}}],
+        # Multiple attributes where one doesn't exist
+        [
+            {"slug": "weight_attribute", "value": {"slug": {"eq": "cotton"}}},
+            {"slug": "non-existing-attr", "value": {"slug": {"eq": "some-value"}}},
+        ],
+        [
+            {"value": {"slug": {"eq": "large"}}},
+            {"slug": "non-existing-attr", "value": {"slug": {"eq": "some-value"}}},
+        ],
+    ],
+)
+def test_product_variants_query_with_non_matching_records(
+    attribute_filter,
+    staff_api_client,
+    product_variant_list,
+    weight_attribute,
+    tag_page_attribute,
+    boolean_attribute,
+    numeric_attribute_without_unit,
+    date_attribute,
+    date_time_attribute,
+    channel_USD,
+):
+    # given
+    tag_attribute = tag_page_attribute
+    tag_attribute.type = "PRODUCT_TYPE"
+    tag_attribute.save()
+
+    weight_attribute.slug = "weight_attribute"
+    weight_attribute.save()
+
+    product_type = product_variant_list[0].product.product_type
+    product_type.variant_attributes.set(
+        [
+            weight_attribute,
+            tag_attribute,
+            boolean_attribute,
+            numeric_attribute_without_unit,
+            date_attribute,
+            date_time_attribute,
+        ]
+    )
+
+    weight_value = weight_attribute.values.get(slug="cotton")
+    tag_value = tag_attribute.values.get(name="About")
+    boolean_value = boolean_attribute.values.filter(boolean=True).first()
+    numeric_value = numeric_attribute_without_unit.values.first()
+    date_time_value = date_time_attribute.values.first()
+    date_value = date_attribute.values.first()
+
+    date_attribute.slug = "date"
+    date_attribute.save()
+    date_time_attribute.slug = "date_time"
+    date_time_attribute.save()
+
+    associate_attribute_values_to_instance(
+        product_variant_list[0],
+        {
+            weight_attribute.pk: [weight_value],
+            tag_attribute.pk: [tag_value],
+            boolean_attribute.pk: [boolean_value],
+            numeric_attribute_without_unit.pk: [numeric_value],
+            date_attribute.pk: [date_value],
+            date_time_attribute.pk: [date_time_value],
+        },
+    )
+
+    variables = {
+        "where": {"attributes": attribute_filter},
+        "channel": channel_USD.slug,
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        PRODUCT_VARIANTS_WHERE_QUERY,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    product_variants_nodes = content["data"]["productVariants"]["edges"]
+    assert len(product_variants_nodes) == 0
+
+
+@pytest.mark.parametrize(
+    ("attribute_where_input", "expected_count_result"),
+    [
+        (
+            [
+                {"slug": "material", "value": {"slug": {"eq": "cotton"}}},
+                {"slug": "tag", "value": {"name": {"oneOf": ["About", "Help"]}}},
+                {"slug": "color", "value": {"slug": {"oneOf": ["red"]}}},
+                {"slug": "boolean", "value": {"boolean": True}},
+            ],
+            1,
+        ),
+        (
+            [
+                {"slug": "material", "value": {"slug": {"eq": "cotton"}}},
+                {"slug": "tag", "value": {"name": {"oneOf": ["About", "Help"]}}},
+            ],
+            1,
+        ),
+        (
+            [
+                {"slug": "material", "value": {"slug": {"eq": "cotton"}}},
+                {"slug": "boolean", "value": {"boolean": False}},
+            ],
+            0,
+        ),
+        (
+            [
+                {"slug": "tag", "value": {"name": {"eq": "About"}}},
+                {"slug": "material", "value": {"slug": {"eq": "cotton"}}},
+            ],
+            1,
+        ),
+        (
+            [
+                {"slug": "material", "value": {"slug": {"eq": "poliester"}}},
+                {"slug": "tag", "value": {"name": {"eq": "Help"}}},
+                {"slug": "boolean", "value": {"boolean": False}},
+            ],
+            0,
+        ),
+        (
+            [
+                {
+                    "slug": "color",
+                    "value": {"slug": {"oneOf": ["red", "blue"]}},
+                },
+                {"slug": "material", "value": {"slug": {"eq": "cotton"}}},
+            ],
+            1,
+        ),
+        (
+            [
+                {"slug": "material", "value": {"slug": {"eq": "cotton"}}},
+                {"slug": "color", "value": {"name": {"eq": "Red"}}},
+            ],
+            1,
+        ),
+        (
+            [
+                {"slug": "material", "value": {"slug": {"eq": "cotton"}}},
+                {"slug": "tag", "value": {"name": {"eq": "About"}}},
+                {"slug": "color", "value": {"slug": {"eq": "red"}}},
+            ],
+            1,
+        ),
+        (
+            [
+                {
+                    "slug": "material",
+                    "value": {"slug": {"oneOf": ["cotton", "poliester"]}},
+                },
+                {"slug": "tag", "value": {"name": {"oneOf": ["About", "Help"]}}},
+            ],
+            2,
+        ),
+        (
+            [
+                {
+                    "slug": "material",
+                    "value": {"slug": {"oneOf": ["cotton", "poliester"]}},
+                },
+                {"slug": "boolean", "value": {"boolean": True}},
+            ],
+            1,
+        ),
+        ([{"value": {"slug": {"oneOf": ["red", "blue"]}}}], 2),
+        (
+            [
+                {"value": {"slug": {"oneOf": ["cotton", "poliester"]}}},
+                {"value": {"boolean": True}},
+            ],
+            1,
+        ),
+    ],
+)
+def test_product_variants_query_with_multiple_attribute_filters(
+    attribute_where_input,
+    expected_count_result,
+    staff_api_client,
+    product_variant_list,
+    weight_attribute,
+    tag_page_attribute,
+    color_attribute,
+    boolean_attribute,
+    channel_USD,
+):
+    # given
+    material_attribute = weight_attribute
+    material_attribute.slug = "material"
+    material_attribute.save()
+
+    tag_attribute = tag_page_attribute
+    tag_attribute.slug = "tag"
+    tag_attribute.type = "PRODUCT_TYPE"
+    tag_attribute.save()
+
+    product_type = product_variant_list[0].product.product_type
+    product_type.variant_attributes.set(
+        [material_attribute, tag_attribute, color_attribute, boolean_attribute]
+    )
+
+    material_value = material_attribute.values.get(slug="cotton")
+    tag_value = tag_attribute.values.get(name="About")
+    color_value = color_attribute.values.get(slug="red")
+    second_color_value = color_attribute.values.get(slug="blue")
+
+    boolean_value = boolean_attribute.values.filter(boolean=True).first()
+
+    associate_attribute_values_to_instance(
+        product_variant_list[0],
+        {
+            material_attribute.pk: [material_value],
+            tag_attribute.pk: [tag_value],
+            color_attribute.pk: [color_value],
+            boolean_attribute.pk: [boolean_value],
+        },
+    )
+
+    tag_value_2 = tag_attribute.values.get(name="Help")
+    second_material_value = material_attribute.values.get(slug="poliester")
+
+    associate_attribute_values_to_instance(
+        product_variant_list[1],
+        {
+            material_attribute.pk: [second_material_value],
+            tag_attribute.pk: [tag_value_2],
+            color_attribute.pk: [second_color_value],
+        },
+    )
+
+    variables = {
+        "where": {"attributes": attribute_where_input},
+        "channel": channel_USD.slug,
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        PRODUCT_VARIANTS_WHERE_QUERY,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    product_variants_nodes = content["data"]["productVariants"]["edges"]
+    assert len(product_variants_nodes) == expected_count_result

--- a/saleor/graphql/product/tests/queries/variants_where/test_over_validation.py
+++ b/saleor/graphql/product/tests/queries/variants_where/test_over_validation.py
@@ -1,0 +1,265 @@
+import pytest
+
+from .....tests.utils import get_graphql_content
+from .shared import PRODUCT_VARIANTS_WHERE_QUERY
+
+
+@pytest.mark.parametrize(
+    "attribute_value_filter",
+    [{"numeric": None}, {"name": None}, {"slug": None}, {"boolean": False}],
+)
+def test_product_variants_query_failed_filter_validation_for_numeric_with_slug_input(
+    attribute_value_filter,
+    staff_api_client,
+    numeric_attribute_without_unit,
+    product_variant_list,
+    channel_USD,
+):
+    # given
+    attr_slug_input = "numeric"
+    numeric_attribute_without_unit.slug = attr_slug_input
+    numeric_attribute_without_unit.save()
+
+    product_type = product_variant_list[0].product.product_type
+    product_type.variant_attributes.add(numeric_attribute_without_unit)
+
+    variables = {
+        "where": {
+            "attributes": [{"slug": attr_slug_input, "value": attribute_value_filter}]
+        },
+        "channel": channel_USD.slug,
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        PRODUCT_VARIANTS_WHERE_QUERY,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response, ignore_errors=True)
+    assert "errors" in content
+    assert content["data"]["productVariants"] is None
+
+
+@pytest.mark.parametrize(
+    "attribute_value_filter",
+    [{"boolean": None}, {"name": None}, {"slug": None}, {"numeric": {"eq": 1.2}}],
+)
+def test_product_variants_query_failed_filter_validation_for_boolean_with_slug_input(
+    attribute_value_filter,
+    staff_api_client,
+    boolean_attribute,
+    product_variant_list,
+    channel_USD,
+):
+    # given
+    attr_slug_input = "boolean"
+    boolean_attribute.slug = attr_slug_input
+    boolean_attribute.save()
+
+    product_type = product_variant_list[0].product.product_type
+    product_type.variant_attributes.add(boolean_attribute)
+
+    variables = {
+        "where": {
+            "attributes": [{"slug": attr_slug_input, "value": attribute_value_filter}]
+        },
+        "channel": channel_USD.slug,
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        PRODUCT_VARIANTS_WHERE_QUERY,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response, ignore_errors=True)
+    assert "errors" in content
+    assert content["data"]["productVariants"] is None
+
+
+@pytest.mark.parametrize(
+    "attribute_value_filter",
+    [
+        {"dateTime": None},
+        {"name": None},
+        {"slug": None},
+        {"numeric": {"eq": 1.2}},
+    ],
+)
+def test_product_variants_query_failed_filter_validation_for_date_attribute_with_slug_input(
+    attribute_value_filter,
+    staff_api_client,
+    date_attribute,
+    product_variant_list,
+    channel_USD,
+):
+    # given
+    attr_slug_input = "date"
+    date_attribute.slug = attr_slug_input
+    date_attribute.save()
+
+    product_type = product_variant_list[0].product.product_type
+    product_type.variant_attributes.add(date_attribute)
+
+    variables = {
+        "where": {
+            "attributes": [{"slug": attr_slug_input, "value": attribute_value_filter}]
+        },
+        "channel": channel_USD.slug,
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        PRODUCT_VARIANTS_WHERE_QUERY,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response, ignore_errors=True)
+    assert "errors" in content
+    assert content["data"]["productVariants"] is None
+
+
+@pytest.mark.parametrize(
+    "attribute_value_filter",
+    [
+        {"dateTime": None},
+        {"name": None},
+        {"slug": None},
+        {"numeric": {"eq": 1.2}},
+        {"date": None},
+    ],
+)
+def test_product_variants_query_failed_filter_validation_for_datetime_attribute_with_slug_input(
+    attribute_value_filter,
+    staff_api_client,
+    date_time_attribute,
+    product_variant_list,
+    channel_USD,
+):
+    # given
+    attr_slug_input = "date_time"
+    date_time_attribute.slug = attr_slug_input
+    date_time_attribute.save()
+
+    product_type = product_variant_list[0].product.product_type
+    product_type.variant_attributes.add(date_time_attribute)
+
+    variables = {
+        "where": {
+            "attributes": [{"slug": attr_slug_input, "value": attribute_value_filter}]
+        },
+        "channel": channel_USD.slug,
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        PRODUCT_VARIANTS_WHERE_QUERY,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response, ignore_errors=True)
+    assert "errors" in content
+    assert content["data"]["productVariants"] is None
+
+
+@pytest.mark.parametrize(
+    "attribute_value_filter",
+    [
+        {"slug": None, "value": None},
+        {"slug": None, "value": {"name": {"eq": "name"}}},
+    ],
+)
+def test_product_variants_query_failed_filter_validation_null_in_input(
+    attribute_value_filter,
+    staff_api_client,
+    channel_USD,
+):
+    # given
+    variables = {
+        "where": {"attributes": [attribute_value_filter]},
+        "channel": channel_USD.slug,
+    }
+    # when
+    response = staff_api_client.post_graphql(
+        PRODUCT_VARIANTS_WHERE_QUERY,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response, ignore_errors=True)
+    assert "errors" in content
+    assert content["data"]["productVariants"] is None
+
+
+@pytest.mark.parametrize(
+    "attribute_value_filter",
+    [
+        {"slug": None},
+        {"name": None},
+        {
+            "slug": {"eq": "true_slug"},
+            "name": {"eq": "name"},
+        },
+        {
+            "slug": {"oneOf": ["true_slug"]},
+            "name": {"oneOf": ["name"]},
+        },
+    ],
+)
+def test_product_variants_query_failed_filter_validation_for_basic_value_fields_with_attr_slug(
+    attribute_value_filter,
+    staff_api_client,
+    channel_USD,
+):
+    # given
+    attr_slug_input = "product-size"
+
+    variables = {
+        "where": {
+            "attributes": [{"slug": attr_slug_input, "value": attribute_value_filter}]
+        },
+        "channel": channel_USD.slug,
+    }
+    # when
+    response = staff_api_client.post_graphql(
+        PRODUCT_VARIANTS_WHERE_QUERY,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response, ignore_errors=True)
+    assert "errors" in content
+    assert content["data"]["productVariants"] is None
+
+
+def test_product_variants_query_failed_filter_validation_for_duplicated_attr_slug(
+    staff_api_client,
+    channel_USD,
+):
+    # given
+    attr_slug_input = "product-size"
+
+    variables = {
+        "where": {
+            "attributes": [
+                {"slug": attr_slug_input},
+                {"slug": attr_slug_input},
+            ]
+        },
+        "channel": channel_USD.slug,
+    }
+    # when
+    response = staff_api_client.post_graphql(
+        PRODUCT_VARIANTS_WHERE_QUERY,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response, ignore_errors=True)
+    assert "errors" in content
+    assert content["data"]["productVariants"] is None

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -8361,11 +8361,28 @@ input ProductVariantWhereInput @doc(category: "Products") {
   """Filter by when was the most recent update."""
   updatedAt: DateTimeRangeInput
 
+  """
+  Filter by attributes associated with the variant.
+  
+  Added in Saleor 3.22.
+  """
+  attributes: [AssignedAttributeWhereInput!]
+
   """List of conditions that must be met."""
   AND: [ProductVariantWhereInput!]
 
   """A list of conditions of which at least one must be met."""
   OR: [ProductVariantWhereInput!]
+}
+
+input AssignedAttributeWhereInput {
+  """Filter by attribute slug."""
+  slug: String
+
+  """
+  Filter by value of the attribute. Only one value input field is allowed. If provided more than one, the error will be raised.
+  """
+  value: AssignedAttributeValueInput
 }
 
 input ProductVariantSortingInput @doc(category: "Products") {
@@ -13077,16 +13094,6 @@ input MetadataValueFilterInput {
 
   """The value included in."""
   oneOf: [String!]
-}
-
-input AssignedAttributeWhereInput {
-  """Filter by attribute slug."""
-  slug: String
-
-  """
-  Filter by value of the attribute. Only one value input field is allowed. If provided more than one, the error will be raised.
-  """
-  value: AssignedAttributeValueInput
 }
 
 type PageTypeCountableConnection @doc(category: "Pages") {


### PR DESCRIPTION
Recreated from original PR: https://github.com/saleor/saleor/pull/18011

I want to merge this change because It adds the ability to filter variants based on their associated attributes.

```graphql
{
  productVariants(first:10, channel:"default-channel", where:{
    attributes:[
      {slug: "score", value:{numeric:{range:{gte:10}}}}
      {value: {slug: {oneOf:["384_3", "384_4"]}}}
    ]
  }){
    edges{
      node{
        id
      }
    }
  }
}
```
Note: This PR also adds `reference` input, but to keep the PR "small" I will add it separatly.

<...